### PR TITLE
feat: Migrate Author.HardcoverRef from slug to canonical Hardcover id

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"time"
 
+	"github.com/bobbyrward/stronghold/internal/config"
+	"github.com/bobbyrward/stronghold/internal/hardcover"
 	"github.com/bobbyrward/stronghold/internal/models"
 	"github.com/spf13/cobra"
+	"gorm.io/gorm"
 )
 
 func createDoctorCmd() *cobra.Command {
@@ -17,8 +22,86 @@ func createDoctorCmd() *cobra.Command {
 
 	doctorCmd.AddCommand(createDoctorMigrateCmd())
 	doctorCmd.AddCommand(createDoctorInitBookSearchCmd())
+	doctorCmd.AddCommand(createDoctorBackfillHardcoverRefsCmd())
 
 	return doctorCmd
+}
+
+func createDoctorBackfillHardcoverRefsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "backfill-hardcover-refs",
+		Short: "Rewrite slug-based Author.HardcoverRef values to canonical Hardcover ids",
+		Long: `Existing authors may have HardcoverRef set to a Hardcover slug. Slugs change and
+die when Hardcover merges duplicates, so refs should hold the canonical author id.
+This command resolves each slug ref to its canonical id and rewrites it. Refs that
+already parse as an integer are left untouched (idempotent), and slugs that cannot
+be resolved are reported and left untouched.`,
+		RunE: runDoctorBackfillHardcoverRefsCmd,
+	}
+}
+
+func runDoctorBackfillHardcoverRefsCmd(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	slog.InfoContext(ctx, "Backfilling Hardcover refs")
+
+	db, err := models.ConnectDB()
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+
+	client := hardcover.NewClient(config.Config.Hardcover.ApiToken)
+
+	// Hardcover allows 60 req/min; 1 request/second keeps us at the limit.
+	rewritten, skipped, unresolved, err := backfillHardcoverRefs(ctx, db, client, time.Second)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Backfill complete: %d rewritten, %d already ids, %d unresolved\n", rewritten, skipped, unresolved)
+	return nil
+}
+
+// backfillHardcoverRefs rewrites slug-based Author.HardcoverRef values to canonical
+// Hardcover ids. Refs that already parse as an int are skipped (idempotent); slugs
+// that cannot be resolved are reported and left untouched.
+func backfillHardcoverRefs(ctx context.Context, db *gorm.DB, client hardcover.Client, perRequestDelay time.Duration) (rewritten, skipped, unresolved int, err error) {
+	var authors []models.Author
+	if err := db.Where("hardcover_ref IS NOT NULL").Find(&authors).Error; err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to load authors: %w", err)
+	}
+
+	for _, author := range authors {
+		ref := *author.HardcoverRef
+
+		// Already an id — idempotent skip.
+		if _, convErr := strconv.Atoi(ref); convErr == nil {
+			skipped++
+			continue
+		}
+
+		// ponytail: plain sleep over a rate.Limiter dep — one-off serial loop.
+		time.Sleep(perRequestDelay)
+
+		result, getErr := client.GetAuthorBySlug(ctx, ref)
+		if getErr != nil {
+			return rewritten, skipped, unresolved, fmt.Errorf("failed to resolve slug %q for author %d: %w", ref, author.ID, getErr)
+		}
+		if result == nil {
+			slog.WarnContext(ctx, "Could not resolve slug; leaving untouched", slog.Uint64("author_id", uint64(author.ID)), slog.String("slug", ref))
+			fmt.Printf("UNRESOLVED: author %d (%s) slug %q\n", author.ID, author.Name, ref)
+			unresolved++
+			continue
+		}
+
+		if updErr := db.Model(&author).Update("hardcover_ref", result.ID).Error; updErr != nil {
+			return rewritten, skipped, unresolved, fmt.Errorf("failed to update author %d: %w", author.ID, updErr)
+		}
+		slog.InfoContext(ctx, "Rewrote hardcover_ref", slog.Uint64("author_id", uint64(author.ID)), slog.String("slug", ref), slog.String("id", result.ID))
+		rewritten++
+	}
+
+	return rewritten, skipped, unresolved, nil
 }
 
 func createDoctorMigrateCmd() *cobra.Command {

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bobbyrward/stronghold/internal/hardcover"
+	"github.com/bobbyrward/stronghold/internal/models"
+)
+
+func strptr(s string) *string { return &s }
+
+func TestBackfillHardcoverRefs(t *testing.T) {
+	db, err := models.ConnectTestDB()
+	require.NoError(t, err)
+
+	hc := hardcover.NewMockClient()
+	hc.AddAuthor("1", "brandon-sanderson", "Brandon Sanderson")
+
+	slugAuthor := models.Author{Name: "Brandon Sanderson", HardcoverRef: strptr("brandon-sanderson")}
+	idAuthor := models.Author{Name: "Already Id", HardcoverRef: strptr("42")}
+	unknownAuthor := models.Author{Name: "Dead Slug", HardcoverRef: strptr("gone-slug")}
+	noRefAuthor := models.Author{Name: "No Ref"}
+	require.NoError(t, db.Create(&slugAuthor).Error)
+	require.NoError(t, db.Create(&idAuthor).Error)
+	require.NoError(t, db.Create(&unknownAuthor).Error)
+	require.NoError(t, db.Create(&noRefAuthor).Error)
+
+	rewritten, skipped, unresolved, err := backfillHardcoverRefs(context.Background(), db, hc, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, rewritten)
+	assert.Equal(t, 1, skipped)
+	assert.Equal(t, 1, unresolved)
+
+	var gotSlug, gotID, gotUnknown models.Author
+	require.NoError(t, db.First(&gotSlug, slugAuthor.ID).Error)
+	assert.Equal(t, "1", *gotSlug.HardcoverRef, "slug ref should be rewritten to canonical id")
+
+	require.NoError(t, db.First(&gotID, idAuthor.ID).Error)
+	assert.Equal(t, "42", *gotID.HardcoverRef, "numeric ref should be untouched")
+
+	require.NoError(t, db.First(&gotUnknown, unknownAuthor.ID).Error)
+	assert.Equal(t, "gone-slug", *gotUnknown.HardcoverRef, "unresolved slug should be left untouched")
+}

--- a/internal/hardcover/client.go
+++ b/internal/hardcover/client.go
@@ -7,6 +7,10 @@ type Client interface {
 	// SearchAuthors searches for authors by name query.
 	SearchAuthors(ctx context.Context, query string) ([]AuthorSearchResult, error)
 
-	// GetAuthorBySlug retrieves an author by their unique slug.
+	// GetAuthorBySlug retrieves an author by their slug. Only used by the
+	// slug→id backfill; new links validate by id.
 	GetAuthorBySlug(ctx context.Context, slug string) (*AuthorSearchResult, error)
+
+	// GetAuthorByID retrieves an author by their canonical id.
+	GetAuthorByID(ctx context.Context, id string) (*AuthorSearchResult, error)
 }

--- a/internal/hardcover/mock_client.go
+++ b/internal/hardcover/mock_client.go
@@ -7,9 +7,10 @@ import (
 
 // MockClient is a mock implementation of the Hardcover Client interface for testing.
 type MockClient struct {
-	Authors             map[string]AuthorSearchResult                                       // slug -> result
+	Authors             map[string]AuthorSearchResult // id -> result
 	SearchAuthorsFunc   func(ctx context.Context, query string) ([]AuthorSearchResult, error)
 	GetAuthorBySlugFunc func(ctx context.Context, slug string) (*AuthorSearchResult, error)
+	GetAuthorByIDFunc   func(ctx context.Context, id string) (*AuthorSearchResult, error)
 }
 
 // Compile-time check that MockClient implements Client interface.
@@ -23,8 +24,8 @@ func NewMockClient() *MockClient {
 }
 
 // AddAuthor adds an author to the mock client's internal data store.
-func (m *MockClient) AddAuthor(slug, name string) {
-	m.Authors[slug] = AuthorSearchResult{Slug: slug, Name: name}
+func (m *MockClient) AddAuthor(id, slug, name string) {
+	m.Authors[id] = AuthorSearchResult{ID: id, Slug: slug, Name: name}
 }
 
 // SearchAuthors searches for authors by name query.
@@ -45,16 +46,30 @@ func (m *MockClient) SearchAuthors(ctx context.Context, query string) ([]AuthorS
 	return results, nil
 }
 
-// GetAuthorBySlug retrieves an author by their unique slug.
+// GetAuthorBySlug retrieves an author by their slug.
 // If GetAuthorBySlugFunc is set, it delegates to that function.
-// Otherwise, it looks up the author in the Authors map.
+// Otherwise, it scans the Authors map for a matching slug.
 func (m *MockClient) GetAuthorBySlug(ctx context.Context, slug string) (*AuthorSearchResult, error) {
 	if m.GetAuthorBySlugFunc != nil {
 		return m.GetAuthorBySlugFunc(ctx, slug)
 	}
-	// Default: lookup in Authors map
-	if author, ok := m.Authors[slug]; ok {
-		return &author, nil
+	for _, author := range m.Authors {
+		if author.Slug == slug {
+			return &author, nil
+		}
 	}
 	return nil, nil // Not found returns nil, not error
+}
+
+// GetAuthorByID retrieves an author by their canonical id.
+// If GetAuthorByIDFunc is set, it delegates to that function.
+// Otherwise, it looks up the author in the Authors map.
+func (m *MockClient) GetAuthorByID(ctx context.Context, id string) (*AuthorSearchResult, error) {
+	if m.GetAuthorByIDFunc != nil {
+		return m.GetAuthorByIDFunc(ctx, id)
+	}
+	if author, ok := m.Authors[id]; ok {
+		return &author, nil
+	}
+	return nil, nil
 }

--- a/internal/hardcover/real_client.go
+++ b/internal/hardcover/real_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/hasura/go-graphql-client"
 )
@@ -29,20 +30,42 @@ func NewClient(token string) *RealClient {
 	}
 }
 
+// authorRow is the shared GraphQL selection for an author plus its canonical
+// (merge target). Hardcover merges duplicate authors; when canonical is set it
+// is the live author, so id/slug/name must all be resolved from it as a unit.
+type authorRow struct {
+	ID   int    `graphql:"id"`
+	Name string `graphql:"name"`
+	Slug string `graphql:"slug"`
+
+	Canonical *struct {
+		ID   int    `graphql:"id"`
+		Name string `graphql:"name"`
+		Slug string `graphql:"slug"`
+	}
+}
+
+func (a authorRow) toResult() AuthorSearchResult {
+	if a.Canonical != nil {
+		return AuthorSearchResult{
+			ID:   strconv.Itoa(a.Canonical.ID),
+			Slug: a.Canonical.Slug,
+			Name: a.Canonical.Name,
+		}
+	}
+	return AuthorSearchResult{
+		ID:   strconv.Itoa(a.ID),
+		Slug: a.Slug,
+		Name: a.Name,
+	}
+}
+
 // SearchAuthors searches for authors by name query using the Hardcover GraphQL API.
 func (c *RealClient) SearchAuthors(ctx context.Context, query string) ([]AuthorSearchResult, error) {
 	slog.InfoContext(ctx, "Searching Hardcover authors", slog.String("query", query))
 
 	var q struct {
-		Authors []struct {
-			Name string `graphql:"name"`
-			Slug string `graphql:"slug"`
-
-			Canonical *struct {
-				Name string `graphql:"name"`
-				Slug string `graphql:"slug"`
-			}
-		} `graphql:"authors(where: {name: {_eq: $name}})"`
+		Authors []authorRow `graphql:"authors(where: {name: {_eq: $name}})"`
 	}
 
 	variables := map[string]any{
@@ -55,34 +78,20 @@ func (c *RealClient) SearchAuthors(ctx context.Context, query string) ([]AuthorS
 	}
 
 	searchResults := make([]AuthorSearchResult, len(q.Authors))
-
 	for idx, author := range q.Authors {
 		slog.DebugContext(ctx, "Found author", slog.String("name", author.Name), slog.String("slug", author.Slug), slog.Any("canonical", author.Canonical))
-		if author.Canonical != nil {
-			searchResults[idx] = AuthorSearchResult{
-				Slug: author.Canonical.Slug,
-				Name: author.Canonical.Name,
-			}
-		} else {
-			searchResults[idx] = AuthorSearchResult{
-				Slug: author.Slug,
-				Name: author.Name,
-			}
-		}
+		searchResults[idx] = author.toResult()
 	}
 
 	return searchResults, nil
 }
 
-// GetAuthorBySlug retrieves an author by their unique slug using the Hardcover GraphQL API.
+// GetAuthorBySlug retrieves an author by their slug using the Hardcover GraphQL API.
 func (c *RealClient) GetAuthorBySlug(ctx context.Context, slug string) (*AuthorSearchResult, error) {
 	slog.InfoContext(ctx, "Getting Hardcover author by slug", slog.String("slug", slug))
 
 	var q struct {
-		Authors []struct {
-			Name string `graphql:"name"`
-			Slug string `graphql:"slug"`
-		} `graphql:"authors(where: {slug: {_eq: $slug}})"`
+		Authors []authorRow `graphql:"authors(where: {slug: {_eq: $slug}})"`
 	}
 
 	variables := map[string]any{
@@ -104,8 +113,37 @@ func (c *RealClient) GetAuthorBySlug(ctx context.Context, slug string) (*AuthorS
 		return nil, nil
 	}
 
-	return &AuthorSearchResult{
-		Slug: q.Authors[0].Slug,
-		Name: q.Authors[0].Name,
-	}, nil
+	result := q.Authors[0].toResult()
+	return &result, nil
+}
+
+// GetAuthorByID retrieves an author by their canonical id using the Hardcover GraphQL API.
+func (c *RealClient) GetAuthorByID(ctx context.Context, id string) (*AuthorSearchResult, error) {
+	slog.InfoContext(ctx, "Getting Hardcover author by id", slog.String("id", id))
+
+	intID, err := strconv.Atoi(id)
+	if err != nil {
+		slog.WarnContext(ctx, "Invalid hardcover author id", slog.String("id", id))
+		return nil, nil
+	}
+
+	var q struct {
+		Authors []authorRow `graphql:"authors(where: {id: {_eq: $id}})"`
+	}
+
+	variables := map[string]any{
+		"id": intID,
+	}
+
+	if err := c.graphqlClient.Query(ctx, &q, variables); err != nil {
+		return nil, err
+	}
+
+	if len(q.Authors) == 0 {
+		slog.WarnContext(ctx, "No author found with given id", slog.String("id", id))
+		return nil, nil
+	}
+
+	result := q.Authors[0].toResult()
+	return &result, nil
 }

--- a/internal/hardcover/real_client_test.go
+++ b/internal/hardcover/real_client_test.go
@@ -1,0 +1,27 @@
+package hardcover
+
+import "testing"
+
+func TestAuthorRowToResult(t *testing.T) {
+	t.Run("no canonical uses own id/slug/name", func(t *testing.T) {
+		row := authorRow{ID: 42, Name: "Brandon Sanderson", Slug: "brandon-sanderson"}
+		got := row.toResult()
+		if got.ID != "42" || got.Slug != "brandon-sanderson" || got.Name != "Brandon Sanderson" {
+			t.Fatalf("unexpected result: %+v", got)
+		}
+	})
+
+	t.Run("canonical (merged) resolves id/slug/name as a unit from canonical", func(t *testing.T) {
+		row := authorRow{ID: 7, Name: "Old Name", Slug: "old-slug"}
+		row.Canonical = &struct {
+			ID   int    `graphql:"id"`
+			Name string `graphql:"name"`
+			Slug string `graphql:"slug"`
+		}{ID: 99, Name: "New Name", Slug: "new-slug"}
+
+		got := row.toResult()
+		if got.ID != "99" || got.Slug != "new-slug" || got.Name != "New Name" {
+			t.Fatalf("expected canonical values, got: %+v", got)
+		}
+	})
+}

--- a/internal/hardcover/types.go
+++ b/internal/hardcover/types.go
@@ -2,6 +2,7 @@ package hardcover
 
 // AuthorSearchResult represents an author returned from Hardcover API searches.
 type AuthorSearchResult struct {
-	Slug string
+	ID   string // canonical author id (stable); used as Author.HardcoverRef
+	Slug string // for UI display + hardcover.app link only
 	Name string
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -106,7 +106,7 @@ type TorrentCategory struct {
 type Author struct {
 	CommonFields
 	Name         string  `gorm:"not null;uniqueIndex"`
-	HardcoverRef *string // nullable until linked; slug/UUID TBD
+	HardcoverRef *string // ponytail: canonical Hardcover author id as decimal string; nil until linked. slug kept only for UI/link.
 }
 
 // AuthorAlias represents an additional alias for an Author

--- a/internal/www/api/authors.go
+++ b/internal/www/api/authors.go
@@ -46,7 +46,7 @@ func (h AuthorHandler) RequestToModel(c echo.Context, ctx context.Context, db *g
 	// Validate hardcover_ref if provided
 	if req.HardcoverRef != nil {
 		slog.DebugContext(ctx, "Validating hardcover_ref", slog.String("ref", *req.HardcoverRef))
-		author, err := h.hardcoverClient.GetAuthorBySlug(ctx, *req.HardcoverRef)
+		author, err := h.hardcoverClient.GetAuthorByID(ctx, *req.HardcoverRef)
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to validate hardcover_ref", slog.Any("error", err))
 			return models.Author{}, InternalError(c, ctx, "Failed to validate hardcover_ref", err)
@@ -56,6 +56,8 @@ func (h AuthorHandler) RequestToModel(c echo.Context, ctx context.Context, db *g
 			return models.Author{}, BadRequest(c, ctx, "invalid hardcover_ref: author not found on Hardcover")
 		}
 		slog.InfoContext(ctx, "Hardcover ref validated", slog.String("ref", *req.HardcoverRef), slog.String("name", author.Name))
+		// Persist the canonical id, not the submitted ref (which may be a merged duplicate's id).
+		req.HardcoverRef = &author.ID
 	}
 
 	return models.Author{
@@ -75,7 +77,7 @@ func (h AuthorHandler) UpdateModel(c echo.Context, ctx context.Context, db *gorm
 		// Only validate if it's different from current
 		if row.HardcoverRef == nil || *row.HardcoverRef != *req.HardcoverRef {
 			slog.DebugContext(ctx, "Validating hardcover_ref on update", slog.String("ref", *req.HardcoverRef))
-			author, err := h.hardcoverClient.GetAuthorBySlug(ctx, *req.HardcoverRef)
+			author, err := h.hardcoverClient.GetAuthorByID(ctx, *req.HardcoverRef)
 			if err != nil {
 				slog.ErrorContext(ctx, "Failed to validate hardcover_ref", slog.Any("error", err))
 				return InternalError(c, ctx, "Failed to validate hardcover_ref", err)
@@ -85,6 +87,8 @@ func (h AuthorHandler) UpdateModel(c echo.Context, ctx context.Context, db *gorm
 				return BadRequest(c, ctx, "invalid hardcover_ref: author not found on Hardcover")
 			}
 			slog.InfoContext(ctx, "Hardcover ref validated", slog.String("ref", *req.HardcoverRef), slog.String("name", author.Name))
+			// Persist the canonical id, not the submitted ref (which may be a merged duplicate's id).
+			req.HardcoverRef = &author.ID
 		}
 	}
 

--- a/internal/www/api/authors_test.go
+++ b/internal/www/api/authors_test.go
@@ -139,14 +139,15 @@ func TestAuthors_HardcoverValidation(t *testing.T) {
 	e, cleanup := SetupTestServer(t)
 	defer cleanup()
 
-	// The mock client in testing.go has these authors:
-	// - "brandon-sanderson" -> "Brandon Sanderson"
-	// - "brandon-mull" -> "Brandon Mull"
-	// - "patrick-rothfuss" -> "Patrick Rothfuss"
-	// - "joe-abercrombie" -> "Joe Abercrombie"
+	// The mock client in testing.go has these authors (id, slug, name):
+	// - "1" / "brandon-sanderson" -> "Brandon Sanderson"
+	// - "2" / "brandon-mull" -> "Brandon Mull"
+	// - "3" / "patrick-rothfuss" -> "Patrick Rothfuss"
+	// - "4" / "joe-abercrombie" -> "Joe Abercrombie"
+	// HardcoverRef now stores the canonical id, not the slug.
 
 	t.Run("Create with valid hardcover_ref succeeds", func(t *testing.T) {
-		body := `{"name": "Brandon Sanderson", "hardcover_ref": "brandon-sanderson"}`
+		body := `{"name": "Brandon Sanderson", "hardcover_ref": "1"}`
 		req := httptest.NewRequest(http.MethodPost, "/api/authors", bytes.NewBufferString(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -158,11 +159,28 @@ func TestAuthors_HardcoverValidation(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &author)
 		require.NoError(t, err)
 		assert.NotNil(t, author.HardcoverRef)
-		assert.Equal(t, "brandon-sanderson", *author.HardcoverRef)
+		assert.Equal(t, "1", *author.HardcoverRef)
+	})
+
+	t.Run("Create with merged (non-canonical) ref stores canonical id", func(t *testing.T) {
+		// id "5" is a merged duplicate that resolves to canonical "1".
+		body := `{"name": "Merged Ref Author", "hardcover_ref": "5"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/authors", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+
+		var author AuthorResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &author)
+		require.NoError(t, err)
+		require.NotNil(t, author.HardcoverRef)
+		assert.Equal(t, "1", *author.HardcoverRef, "should persist canonical id, not submitted merged id")
 	})
 
 	t.Run("Create with invalid hardcover_ref returns 400", func(t *testing.T) {
-		body := `{"name": "Invalid Author", "hardcover_ref": "nonexistent-author-slug"}`
+		body := `{"name": "Invalid Author", "hardcover_ref": "999999"}`
 		req := httptest.NewRequest(http.MethodPost, "/api/authors", bytes.NewBufferString(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -201,7 +219,7 @@ func TestAuthors_HardcoverValidation(t *testing.T) {
 		author := createTestAuthor(t, e, "Author For Update")
 
 		// Update with valid hardcover_ref
-		body := `{"name": "Author For Update", "hardcover_ref": "patrick-rothfuss"}`
+		body := `{"name": "Author For Update", "hardcover_ref": "3"}`
 		req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/authors/%d", author.ID), bytes.NewBufferString(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -213,7 +231,7 @@ func TestAuthors_HardcoverValidation(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &updated)
 		require.NoError(t, err)
 		assert.NotNil(t, updated.HardcoverRef)
-		assert.Equal(t, "patrick-rothfuss", *updated.HardcoverRef)
+		assert.Equal(t, "3", *updated.HardcoverRef)
 	})
 
 	t.Run("Update with invalid hardcover_ref returns 400", func(t *testing.T) {
@@ -221,7 +239,7 @@ func TestAuthors_HardcoverValidation(t *testing.T) {
 		author := createTestAuthor(t, e, "Author For Invalid Update")
 
 		// Try to update with invalid hardcover_ref
-		body := `{"name": "Author For Invalid Update", "hardcover_ref": "invalid-slug-here"}`
+		body := `{"name": "Author For Invalid Update", "hardcover_ref": "888888"}`
 		req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/authors/%d", author.ID), bytes.NewBufferString(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()

--- a/internal/www/api/hardcover.go
+++ b/internal/www/api/hardcover.go
@@ -11,6 +11,7 @@ import (
 
 // HardcoverAuthorSearchResponse represents an author result from Hardcover search.
 type HardcoverAuthorSearchResponse struct {
+	ID   string `json:"id"`
 	Slug string `json:"slug"`
 	Name string `json:"name"`
 }
@@ -35,6 +36,7 @@ func SearchHardcoverAuthors(client hardcover.Client) echo.HandlerFunc {
 		response := make([]HardcoverAuthorSearchResponse, len(results))
 		for i, r := range results {
 			response[i] = HardcoverAuthorSearchResponse{
+				ID:   r.ID,
 				Slug: r.Slug,
 				Name: r.Name,
 			}

--- a/internal/www/api/hardcover_test.go
+++ b/internal/www/api/hardcover_test.go
@@ -32,6 +32,7 @@ func TestHardcoverSearch(t *testing.T) {
 		// Verify structure and content
 		names := make(map[string]string)
 		for _, r := range results {
+			assert.NotEmpty(t, r.ID)
 			assert.NotEmpty(t, r.Slug)
 			assert.NotEmpty(t, r.Name)
 			names[r.Slug] = r.Name
@@ -53,6 +54,7 @@ func TestHardcoverSearch(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Len(t, results, 1)
+		assert.Equal(t, "3", results[0].ID)
 		assert.Equal(t, "patrick-rothfuss", results[0].Slug)
 		assert.Equal(t, "Patrick Rothfuss", results[0].Name)
 	})

--- a/internal/www/api/testing.go
+++ b/internal/www/api/testing.go
@@ -56,11 +56,15 @@ func SetupTestServerWithDB(db *gorm.DB) *echo.Echo {
 	apiGroup := e.Group("/api")
 	hc := hardcover.NewMockClient()
 
-	// Add test authors to the mock Hardcover client
-	hc.AddAuthor("brandon-sanderson", "Brandon Sanderson")
-	hc.AddAuthor("brandon-mull", "Brandon Mull")
-	hc.AddAuthor("patrick-rothfuss", "Patrick Rothfuss")
-	hc.AddAuthor("joe-abercrombie", "Joe Abercrombie")
+	// Add test authors to the mock Hardcover client (id, slug, name)
+	hc.AddAuthor("1", "brandon-sanderson", "Brandon Sanderson")
+	hc.AddAuthor("2", "brandon-mull", "Brandon Mull")
+	hc.AddAuthor("3", "patrick-rothfuss", "Patrick Rothfuss")
+	hc.AddAuthor("4", "joe-abercrombie", "Joe Abercrombie")
+
+	// Merged duplicate: id "5" has been merged into canonical "1", so looking it
+	// up resolves to canonical id "1" (mirrors Hardcover's canonical_id behavior).
+	hc.Authors["5"] = hardcover.AuthorSearchResult{ID: "1", Slug: "brandon-sanderson", Name: "Merged Duplicate"}
 
 	RegisterRoutes(apiGroup, db, hc)
 

--- a/web/src/components/AuthorRow.vue
+++ b/web/src/components/AuthorRow.vue
@@ -184,7 +184,7 @@ function truncateHash(hash: string, length: number = 12): string {
 }
 
 function handleHardcoverSelect(author: HardcoverAuthorSearchResult) {
-  editData.value.hardcover_ref = author.slug
+  editData.value.hardcover_ref = author.id
 }
 
 function handleSave() {

--- a/web/src/components/common/HardcoverSearchModal.vue
+++ b/web/src/components/common/HardcoverSearchModal.vue
@@ -95,7 +95,7 @@ function closeModal() {
                         </div>
 
                         <div v-else-if="results.length > 0" class="list-group">
-                            <div v-for="author in results" :key="author.slug"
+                            <div v-for="author in results" :key="author.id"
                                 class="list-group-item list-group-item-action">
 
                                 <div class="row">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -38,6 +38,7 @@ export interface LibraryRequest {
 
 // Hardcover search
 export interface HardcoverAuthorSearchResult {
+    id: string
     slug: string
     name: string
 }

--- a/web/src/views/AuthorsView.vue
+++ b/web/src/views/AuthorsView.vue
@@ -90,7 +90,7 @@ function openHardcoverModal() {
 }
 
 function handleHardcoverSelect(author: HardcoverAuthorSearchResult) {
-  newAuthor.value.hardcover_ref = author.slug
+  newAuthor.value.hardcover_ref = author.id
   if (!newAuthor.value.name) {
     newAuthor.value.name = author.name
   }


### PR DESCRIPTION
## Migrate `Author.HardcoverRef` from slug → canonical Hardcover author id

### Why
`HardcoverRef` stored the Hardcover author **slug**, which is unstable: slugs change when an author's name changes, and they die outright when Hardcover merges duplicate authors (the loser's slug disappears). Slugs also aren't reliably unique. This switches the ref to the canonical author **id** (a stable int), keeping the slug only for UI display and the `hardcover.app/authors/<slug>` link.

### What changed

**`internal/hardcover`**
- `AuthorSearchResult` gains `ID`; `Client` gains `GetAuthorByID`.
- Search/get queries now select `id` plus `canonical { id slug name }` and resolve id/slug/name from `canonical` as a unit when present — fixing a latent bug where the canonical id was dropped.
- Mock client keyed by id, with `GetAuthorByIDFunc`.

**API**
- Author create/update validate the ref via `GetAuthorByID` and **persist the resolved canonical `id`**, not the submitted ref — so a merged duplicate's id is normalized to canonical on write.
- Hardcover search response includes `id`.

**Frontend**
- `HardcoverAuthorSearchResult` gains `id`; selecting an author now stores `author.id` as the ref. The search modal still shows and links the slug.

**Backfill**
- New `stronghold doctor backfill-hardcover-refs` rewrites existing slug refs to canonical ids. Idempotent (refs that already parse as an int are skipped), unresolved slugs are reported and left untouched, and it's throttled to 1 req/s to respect Hardcover's 60 req/min limit. Verified working against the real DB.

**Docs**
- `docs/hardcover-api.md` open-question #1 closed; `CONTEXT.md` and the `models.go` field comment updated.

### Out of scope
Making `HardcoverRef` non-null and adding a unique constraint (ADR 0005, later).

### Testing
- Canonical-merge unit test on the resolution logic.
- Backfill test: slug rewritten, numeric ref untouched, dead slug left untouched.
- API test: merged (non-canonical) ref stored as canonical id.
- Existing author/hardcover tests updated to id-based refs (search asserts still check slug).
- `go test ./...`, `go vet`, and `make` (incl. `vue-tsc`) all pass; backfill confirmed working live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)