### PR TITLE
feat: sync author bibliographies from Hardcover

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
-	"time"
 
+	"github.com/bobbyrward/stronghold/internal/catalog"
 	"github.com/bobbyrward/stronghold/internal/config"
 	"github.com/bobbyrward/stronghold/internal/hardcover"
 	"github.com/bobbyrward/stronghold/internal/models"
@@ -23,8 +23,41 @@ func createDoctorCmd() *cobra.Command {
 	doctorCmd.AddCommand(createDoctorMigrateCmd())
 	doctorCmd.AddCommand(createDoctorInitBookSearchCmd())
 	doctorCmd.AddCommand(createDoctorBackfillHardcoverRefsCmd())
+	doctorCmd.AddCommand(createDoctorSyncBibliographyCmd())
 
 	return doctorCmd
+}
+
+func createDoctorSyncBibliographyCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "sync-bibliography",
+		Short: "Fetch each Hardcover-linked author's works and upsert them as Book rows",
+		Long: `For every author with a HardcoverRef, fetch their bibliography from Hardcover
+and upsert each work into the Book catalog (keyed on the Hardcover work id, so
+re-runs update rather than duplicate). Does not create acquisition targets.`,
+		RunE: runDoctorSyncBibliographyCmd,
+	}
+}
+
+func runDoctorSyncBibliographyCmd(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	slog.InfoContext(ctx, "Syncing author bibliographies")
+
+	db, err := models.ConnectDB()
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+
+	client := hardcover.NewClient(config.Config.Hardcover.ApiToken)
+
+	synced, err := catalog.SyncAuthorBibliography(ctx, db, client)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Bibliography sync complete: %d books upserted\n", synced)
+	return nil
 }
 
 func createDoctorBackfillHardcoverRefsCmd() *cobra.Command {
@@ -52,8 +85,7 @@ func runDoctorBackfillHardcoverRefsCmd(cmd *cobra.Command, args []string) error 
 
 	client := hardcover.NewClient(config.Config.Hardcover.ApiToken)
 
-	// Hardcover allows 60 req/min; 1 request/second keeps us at the limit.
-	rewritten, skipped, unresolved, err := backfillHardcoverRefs(ctx, db, client, time.Second)
+	rewritten, skipped, unresolved, err := backfillHardcoverRefs(ctx, db, client)
 	if err != nil {
 		return err
 	}
@@ -65,7 +97,7 @@ func runDoctorBackfillHardcoverRefsCmd(cmd *cobra.Command, args []string) error 
 // backfillHardcoverRefs rewrites slug-based Author.HardcoverRef values to canonical
 // Hardcover ids. Refs that already parse as an int are skipped (idempotent); slugs
 // that cannot be resolved are reported and left untouched.
-func backfillHardcoverRefs(ctx context.Context, db *gorm.DB, client hardcover.Client, perRequestDelay time.Duration) (rewritten, skipped, unresolved int, err error) {
+func backfillHardcoverRefs(ctx context.Context, db *gorm.DB, client hardcover.Client) (rewritten, skipped, unresolved int, err error) {
 	var authors []models.Author
 	if err := db.Where("hardcover_ref IS NOT NULL").Find(&authors).Error; err != nil {
 		return 0, 0, 0, fmt.Errorf("failed to load authors: %w", err)
@@ -80,9 +112,7 @@ func backfillHardcoverRefs(ctx context.Context, db *gorm.DB, client hardcover.Cl
 			continue
 		}
 
-		// ponytail: plain sleep over a rate.Limiter dep — one-off serial loop.
-		time.Sleep(perRequestDelay)
-
+		// Spacing is owned by the client's rate limiter (internal/hardcover).
 		result, getErr := client.GetAuthorBySlug(ctx, ref)
 		if getErr != nil {
 			return rewritten, skipped, unresolved, fmt.Errorf("failed to resolve slug %q for author %d: %w", ref, author.ID, getErr)

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -29,7 +29,7 @@ func TestBackfillHardcoverRefs(t *testing.T) {
 	require.NoError(t, db.Create(&unknownAuthor).Error)
 	require.NoError(t, db.Create(&noRefAuthor).Error)
 
-	rewritten, skipped, unresolved, err := backfillHardcoverRefs(context.Background(), db, hc, 0)
+	rewritten, skipped, unresolved, err := backfillHardcoverRefs(context.Background(), db, hc)
 	require.NoError(t, err)
 	assert.Equal(t, 1, rewritten)
 	assert.Equal(t, 1, skipped)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/mmcdole/gofeed v1.3.0
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/time v0.14.0
 	gopkg.in/vansante/go-ffprobe.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/postgres v1.6.0
@@ -84,6 +85,5 @@ require (
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 )

--- a/internal/catalog/bibliography.go
+++ b/internal/catalog/bibliography.go
@@ -1,0 +1,116 @@
+// Package catalog materializes the book catalog from external sources. It sits
+// above models and hardcover so the same logic is reusable by the doctor CLI, a
+// future scheduler, and web refresh endpoints.
+package catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/bobbyrward/stronghold/internal/hardcover"
+	"github.com/bobbyrward/stronghold/internal/models"
+	"gorm.io/gorm"
+)
+
+// releaseDateLayout is Hardcover's release_date format (BookResult.ReleaseDate).
+const releaseDateLayout = "2006-01-02"
+
+// SyncAuthorBibliography fetches the bibliography of every Hardcover-linked author
+// and upserts each work into the Book catalog, keyed on the Hardcover work id so
+// re-runs update rather than duplicate. A co-authored work is a single Book linked
+// to every tracked contributor (many-to-many). It does not create
+// AcquisitionTargets. Returns the number of distinct works synced.
+func SyncAuthorBibliography(ctx context.Context, db *gorm.DB, client hardcover.Client) (synced int, err error) {
+	var authors []models.Author
+	if err := db.Where("hardcover_ref IS NOT NULL").Find(&authors).Error; err != nil {
+		return 0, fmt.Errorf("failed to load authors: %w", err)
+	}
+
+	slog.InfoContext(ctx, "Syncing author bibliographies", slog.Int("authors", len(authors)))
+
+	// A work co-authored by two tracked authors is returned by both their
+	// GetAuthorBooks calls; count it once.
+	seen := make(map[string]struct{})
+
+	for _, author := range authors {
+		ref := *author.HardcoverRef
+
+		books, getErr := client.GetAuthorBooks(ctx, ref)
+		if getErr != nil {
+			return synced, fmt.Errorf("failed to fetch bibliography for author %d (%s): %w", author.ID, ref, getErr)
+		}
+
+		for _, b := range books {
+			book, upErr := upsertBook(ctx, db, b)
+			if upErr != nil {
+				return synced, upErr
+			}
+
+			// Link this author to the work. GORM upserts the join row, so the
+			// append is idempotent across re-syncs and co-authors.
+			if linkErr := db.Model(book).Association("Authors").Append(&author); linkErr != nil {
+				return synced, fmt.Errorf("failed to link author %d to book %s: %w", author.ID, b.HardcoverID, linkErr)
+			}
+
+			if _, ok := seen[b.HardcoverID]; !ok {
+				seen[b.HardcoverID] = struct{}{}
+				synced++
+			}
+		}
+
+		slog.InfoContext(ctx, "Synced author bibliography",
+			slog.Uint64("author_id", uint64(author.ID)),
+			slog.String("hardcover_ref", ref),
+			slog.Int("books", len(books)))
+	}
+
+	slog.InfoContext(ctx, "Bibliography sync complete", slog.Int("books", synced))
+	return synced, nil
+}
+
+// upsertBook finds the Book for a Hardcover work by its ref, updating title and
+// release date, or creates it if absent. Returns the persisted row (with ID set)
+// so the caller can attach author associations.
+func upsertBook(ctx context.Context, db *gorm.DB, b hardcover.BookResult) (*models.Book, error) {
+	var book models.Book
+	res := db.Where("hardcover_ref = ?", b.HardcoverID).First(&book)
+
+	switch {
+	case errors.Is(res.Error, gorm.ErrRecordNotFound):
+		book = models.Book{
+			HardcoverRef: &b.HardcoverID,
+			Title:        b.Title,
+			ReleaseDate:  parseReleaseDate(ctx, b.ReleaseDate),
+		}
+		if err := db.Create(&book).Error; err != nil {
+			return nil, fmt.Errorf("failed to create book %q (%s): %w", b.Title, b.HardcoverID, err)
+		}
+	case res.Error != nil:
+		return nil, fmt.Errorf("failed to load book %s: %w", b.HardcoverID, res.Error)
+	default:
+		book.Title = b.Title
+		book.ReleaseDate = parseReleaseDate(ctx, b.ReleaseDate)
+		if err := db.Save(&book).Error; err != nil {
+			return nil, fmt.Errorf("failed to update book %q (%s): %w", b.Title, b.HardcoverID, err)
+		}
+	}
+
+	return &book, nil
+}
+
+// parseReleaseDate parses a Hardcover release_date; nil and unparseable values
+// pass through as nil rather than failing the whole sync.
+func parseReleaseDate(ctx context.Context, raw *string) *time.Time {
+	if raw == nil || *raw == "" {
+		return nil
+	}
+	t, err := time.Parse(releaseDateLayout, *raw)
+	if err != nil {
+		slog.WarnContext(ctx, "Unparseable release_date; storing nil", slog.String("value", *raw))
+		return nil
+	}
+	return &t
+}

--- a/internal/catalog/bibliography_test.go
+++ b/internal/catalog/bibliography_test.go
@@ -1,0 +1,106 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bobbyrward/stronghold/internal/hardcover"
+	"github.com/bobbyrward/stronghold/internal/models"
+)
+
+func ptr(s string) *string { return &s }
+
+func TestSyncAuthorBibliography(t *testing.T) {
+	db, err := models.ConnectTestDB()
+	if err != nil {
+		t.Fatalf("ConnectTestDB: %v", err)
+	}
+
+	linked := models.Author{Name: "Brandon Sanderson", HardcoverRef: ptr("100")}
+	other := models.Author{Name: "N.K. Jemisin", HardcoverRef: ptr("200")}
+	unlinked := models.Author{Name: "Unlinked", HardcoverRef: nil}
+	for _, a := range []*models.Author{&linked, &other, &unlinked} {
+		if err := db.Create(a).Error; err != nil {
+			t.Fatalf("create author %s: %v", a.Name, err)
+		}
+	}
+
+	// Work "10" is co-authored: it appears in both authors' bibliographies.
+	coauthored := hardcover.BookResult{HardcoverID: "10", Title: "Co-Authored Work", ReleaseDate: nil}
+	client := hardcover.NewMockClient()
+	client.Books["100"] = []hardcover.BookResult{
+		{HardcoverID: "1", Title: "The Way of Kings", ReleaseDate: ptr("2010-08-31")},
+		{HardcoverID: "2", Title: "Words of Radiance", ReleaseDate: nil},
+		coauthored,
+	}
+	client.Books["200"] = []hardcover.BookResult{
+		{HardcoverID: "3", Title: "The Fifth Season", ReleaseDate: ptr("2015-08-04")},
+		coauthored,
+	}
+
+	ctx := context.Background()
+
+	synced, err := SyncAuthorBibliography(ctx, db, client)
+	if err != nil {
+		t.Fatalf("SyncAuthorBibliography: %v", err)
+	}
+	// Four distinct works (1, 2, 3, 10) — the co-authored work counts once.
+	if synced != 4 {
+		t.Fatalf("expected 4 books synced, got %d", synced)
+	}
+
+	var count int64
+	db.Model(&models.Book{}).Count(&count)
+	if count != 4 {
+		t.Fatalf("expected 4 book rows, got %d", count)
+	}
+
+	// The co-authored work is a single Book linked to both authors.
+	var shared models.Book
+	if err := db.Preload("Authors").Where("hardcover_ref = ?", "10").First(&shared).Error; err != nil {
+		t.Fatalf("find co-authored book: %v", err)
+	}
+	if len(shared.Authors) != 2 {
+		t.Fatalf("expected co-authored book to have 2 authors, got %d", len(shared.Authors))
+	}
+
+	// release_date parsed for the dated book, nil passes through.
+	var wok models.Book
+	if err := db.Where("hardcover_ref = ?", "1").First(&wok).Error; err != nil {
+		t.Fatalf("find book 1: %v", err)
+	}
+	if wok.ReleaseDate == nil || wok.ReleaseDate.Year() != 2010 {
+		t.Fatalf("expected 2010 release date, got %v", wok.ReleaseDate)
+	}
+	var wor models.Book
+	if err := db.Where("hardcover_ref = ?", "2").First(&wor).Error; err != nil {
+		t.Fatalf("find book 2: %v", err)
+	}
+	if wor.ReleaseDate != nil {
+		t.Fatalf("expected nil release date, got %v", wor.ReleaseDate)
+	}
+
+	// Second run upserts: a changed title updates in place, no duplicate rows or
+	// author links.
+	client.Books["100"][0].Title = "The Way of Kings (Revised)"
+	if _, err := SyncAuthorBibliography(ctx, db, client); err != nil {
+		t.Fatalf("second SyncAuthorBibliography: %v", err)
+	}
+	db.Model(&models.Book{}).Count(&count)
+	if count != 4 {
+		t.Fatalf("expected 4 book rows after re-sync, got %d", count)
+	}
+	// Co-authored work still has exactly two author links — Append stayed idempotent.
+	if err := db.Preload("Authors").Where("hardcover_ref = ?", "10").First(&shared).Error; err != nil {
+		t.Fatalf("re-find co-authored book: %v", err)
+	}
+	if len(shared.Authors) != 2 {
+		t.Fatalf("expected 2 authors after re-sync, got %d", len(shared.Authors))
+	}
+	if err := db.Where("hardcover_ref = ?", "1").First(&wok).Error; err != nil {
+		t.Fatalf("re-find book 1: %v", err)
+	}
+	if wok.Title != "The Way of Kings (Revised)" {
+		t.Fatalf("expected updated title, got %q", wok.Title)
+	}
+}

--- a/internal/hardcover/client.go
+++ b/internal/hardcover/client.go
@@ -13,4 +13,8 @@ type Client interface {
 
 	// GetAuthorByID retrieves an author by their canonical id.
 	GetAuthorByID(ctx context.Context, id string) (*AuthorSearchResult, error)
+
+	// GetAuthorBooks fetches an author's bibliography (list of works) by their
+	// canonical id, ordered by release date.
+	GetAuthorBooks(ctx context.Context, id string) ([]BookResult, error)
 }

--- a/internal/hardcover/mock_client.go
+++ b/internal/hardcover/mock_client.go
@@ -8,9 +8,11 @@ import (
 // MockClient is a mock implementation of the Hardcover Client interface for testing.
 type MockClient struct {
 	Authors             map[string]AuthorSearchResult // id -> result
+	Books               map[string][]BookResult       // author id -> bibliography
 	SearchAuthorsFunc   func(ctx context.Context, query string) ([]AuthorSearchResult, error)
 	GetAuthorBySlugFunc func(ctx context.Context, slug string) (*AuthorSearchResult, error)
 	GetAuthorByIDFunc   func(ctx context.Context, id string) (*AuthorSearchResult, error)
+	GetAuthorBooksFunc  func(ctx context.Context, id string) ([]BookResult, error)
 }
 
 // Compile-time check that MockClient implements Client interface.
@@ -20,6 +22,7 @@ var _ Client = (*MockClient)(nil)
 func NewMockClient() *MockClient {
 	return &MockClient{
 		Authors: make(map[string]AuthorSearchResult),
+		Books:   make(map[string][]BookResult),
 	}
 }
 
@@ -72,4 +75,14 @@ func (m *MockClient) GetAuthorByID(ctx context.Context, id string) (*AuthorSearc
 		return &author, nil
 	}
 	return nil, nil
+}
+
+// GetAuthorBooks retrieves an author's bibliography by canonical id.
+// If GetAuthorBooksFunc is set, it delegates to that function.
+// Otherwise, it returns the books stored for that author id.
+func (m *MockClient) GetAuthorBooks(ctx context.Context, id string) ([]BookResult, error) {
+	if m.GetAuthorBooksFunc != nil {
+		return m.GetAuthorBooksFunc(ctx, id)
+	}
+	return m.Books[id], nil
 }

--- a/internal/hardcover/ratelimit_test.go
+++ b/internal/hardcover/ratelimit_test.go
@@ -1,0 +1,49 @@
+package hardcover
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// TestLimiterSpacesAfterBurst verifies the configured limiter paces requests once
+// the burst is exhausted: the next reservation must wait roughly the per-request
+// interval rather than firing immediately.
+func TestLimiterSpacesAfterBurst(t *testing.T) {
+	limiter := rate.NewLimiter(rate.Every(time.Minute/requestsPerMinute), burst)
+
+	// Drain the burst — these are immediate.
+	for i := 0; i < burst; i++ {
+		if d := limiter.Reserve().Delay(); d != 0 {
+			t.Fatalf("burst token %d should be immediate, waited %v", i, d)
+		}
+	}
+
+	// Next one must wait close to the interval (one token / requestsPerMinute).
+	interval := time.Minute / requestsPerMinute
+	if d := limiter.Reserve().Delay(); d <= 0 || d > interval {
+		t.Fatalf("post-burst reservation delay %v, want (0, %v]", d, interval)
+	}
+}
+
+// TestRateLimitedTransportRespectsContext ensures the transport surfaces a
+// cancelled context instead of blocking forever on Wait.
+func TestRateLimitedTransportRespectsContext(t *testing.T) {
+	// Real burst, then drain it: the next Wait must block on the limiter (one
+	// token per hour), so only context cancellation can unblock it. With burst 0
+	// Wait would error on "exceeds burst" before ever consulting the context.
+	limiter := rate.NewLimiter(rate.Every(time.Hour), 1)
+	limiter.Allow() // consume the single burst token
+	tr := &rateLimitedTransport{limiter: limiter, base: http.DefaultTransport}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+	if _, err := tr.RoundTrip(req); err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+}

--- a/internal/hardcover/real_client.go
+++ b/internal/hardcover/real_client.go
@@ -5,9 +5,33 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/hasura/go-graphql-client"
+	"golang.org/x/time/rate"
 )
+
+// Hardcover allows 60 req/min per account. requestsPerMinute keeps headroom under
+// that cap; burst lets interactive single calls fire without waiting.
+const (
+	requestsPerMinute = 50
+	burst             = 5
+)
+
+// rateLimitedTransport blocks each request until the shared limiter grants a
+// token, so every Hardcover call site (sync, web author-add, doctor) shares one
+// budget instead of pacing independently.
+type rateLimitedTransport struct {
+	limiter *rate.Limiter
+	base    http.RoundTripper
+}
+
+func (t *rateLimitedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := t.limiter.Wait(req.Context()); err != nil {
+		return nil, err
+	}
+	return t.base.RoundTrip(req)
+}
 
 // RealClient is the production implementation of the Hardcover API client.
 type RealClient struct {
@@ -20,8 +44,18 @@ var _ Client = (*RealClient)(nil)
 
 // NewClient creates a new Hardcover API client with the given authentication token.
 func NewClient(token string) *RealClient {
+	// ponytail: per-process limiter — a running web server and a separately
+	// invoked doctor CLI each get their own and don't coordinate. Cross-process
+	// (distributed) limiting is out of scope; not a normal workflow.
+	httpClient := &http.Client{
+		Transport: &rateLimitedTransport{
+			limiter: rate.NewLimiter(rate.Every(time.Minute/requestsPerMinute), burst),
+			base:    http.DefaultTransport,
+		},
+	}
+
 	return &RealClient{
-		graphqlClient: graphql.NewClient("https://api.hardcover.app/v1/graphql", http.DefaultClient).
+		graphqlClient: graphql.NewClient("https://api.hardcover.app/v1/graphql", httpClient).
 			WithRequestModifier(func(r *http.Request) {
 				r.Header.Set("Authorization", "Bearer "+token)
 				r.Header.Set("User-Agent", "stronghold/1.0")
@@ -146,4 +180,51 @@ func (c *RealClient) GetAuthorByID(ctx context.Context, id string) (*AuthorSearc
 
 	result := q.Authors[0].toResult()
 	return &result, nil
+}
+
+// bookRow is the GraphQL selection for one work in an author's bibliography.
+type bookRow struct {
+	ID          int     `graphql:"id"`
+	Title       string  `graphql:"title"`
+	ReleaseDate *string `graphql:"release_date"`
+}
+
+func (b bookRow) toResult() BookResult {
+	return BookResult{
+		HardcoverID: strconv.Itoa(b.ID),
+		Title:       b.Title,
+		ReleaseDate: b.ReleaseDate,
+	}
+}
+
+// GetAuthorBooks fetches an author's bibliography by canonical id, ordered by
+// release date. See docs/hardcover-api.md query #2.
+func (c *RealClient) GetAuthorBooks(ctx context.Context, id string) ([]BookResult, error) {
+	slog.InfoContext(ctx, "Getting Hardcover author bibliography", slog.String("id", id))
+
+	intID, err := strconv.Atoi(id)
+	if err != nil {
+		slog.WarnContext(ctx, "Invalid hardcover author id", slog.String("id", id))
+		return nil, nil
+	}
+
+	var q struct {
+		Books []bookRow `graphql:"books(where: {contributions: {author_id: {_eq: $authorId}}}, order_by: {release_date: asc})"`
+	}
+
+	variables := map[string]any{
+		"authorId": intID,
+	}
+
+	if err := c.graphqlClient.Query(ctx, &q, variables); err != nil {
+		return nil, err
+	}
+
+	results := make([]BookResult, len(q.Books))
+	for idx, book := range q.Books {
+		results[idx] = book.toResult()
+	}
+
+	slog.DebugContext(ctx, "Fetched author bibliography", slog.String("id", id), slog.Int("count", len(results)))
+	return results, nil
 }

--- a/internal/hardcover/real_client_test.go
+++ b/internal/hardcover/real_client_test.go
@@ -25,3 +25,20 @@ func TestAuthorRowToResult(t *testing.T) {
 		}
 	})
 }
+
+func TestBookRowToResult(t *testing.T) {
+	t.Run("maps id, title and release date", func(t *testing.T) {
+		date := "2017-11-14"
+		got := bookRow{ID: 123, Title: "Oathbringer", ReleaseDate: &date}.toResult()
+		if got.HardcoverID != "123" || got.Title != "Oathbringer" || got.ReleaseDate == nil || *got.ReleaseDate != date {
+			t.Fatalf("unexpected result: %+v", got)
+		}
+	})
+
+	t.Run("nil release date passes through", func(t *testing.T) {
+		got := bookRow{ID: 1, Title: "Untitled"}.toResult()
+		if got.ReleaseDate != nil {
+			t.Fatalf("expected nil release date, got: %v", *got.ReleaseDate)
+		}
+	})
+}

--- a/internal/hardcover/types.go
+++ b/internal/hardcover/types.go
@@ -6,3 +6,11 @@ type AuthorSearchResult struct {
 	Slug string // for UI display + hardcover.app link only
 	Name string
 }
+
+// BookResult is one work from an author's Hardcover bibliography. Maps to a
+// catalog Book; editions are deliberately not pulled (see docs/hardcover-api.md).
+type BookResult struct {
+	HardcoverID string  // Hardcover books (work) id, stored as decimal string
+	Title       string
+	ReleaseDate *string // ISO date from Hardcover; nil when unknown
+}

--- a/internal/models/catalog_test.go
+++ b/internal/models/catalog_test.go
@@ -1,0 +1,34 @@
+package models
+
+import "testing"
+
+// TestAcquisitionTargetUnique verifies the catalog spine migrates and that a
+// Book may have at most one AcquisitionTarget per BookType.
+func TestAcquisitionTargetUnique(t *testing.T) {
+	db, err := ConnectTestDB()
+	if err != nil {
+		t.Fatalf("ConnectTestDB: %v", err)
+	}
+
+	author := Author{Name: "Brandon Sanderson"}
+	if err := db.Create(&author).Error; err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+
+	book := Book{Authors: []Author{author}, Title: "Oathbringer"}
+	if err := db.Create(&book).Error; err != nil {
+		t.Fatalf("create book: %v", err)
+	}
+
+	var ebook BookType
+	if err := db.Where("name = ?", "ebook").First(&ebook).Error; err != nil {
+		t.Fatalf("find ebook type: %v", err)
+	}
+
+	if err := db.Create(&AcquisitionTarget{BookID: book.ID, BookTypeID: ebook.ID}).Error; err != nil {
+		t.Fatalf("create first target: %v", err)
+	}
+	if err := db.Create(&AcquisitionTarget{BookID: book.ID, BookTypeID: ebook.ID}).Error; err == nil {
+		t.Fatal("expected unique-constraint error on duplicate (book, booktype), got nil")
+	}
+}

--- a/internal/models/db.go
+++ b/internal/models/db.go
@@ -160,6 +160,9 @@ func AutoMigrate(db *gorm.DB) error {
 		&AuthorAlias{},
 		&AuthorSubscription{},
 		&AuthorSubscriptionItem{},
+		// Catalog spine
+		&Book{},
+		&AcquisitionTarget{},
 		&EventLog{},
 	)
 	if err != nil {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -132,6 +132,30 @@ type AuthorSubscription struct {
 	AudiobookLibrary   Library `gorm:"foreignKey:AudiobookLibraryID;constraint:OnUpdate:CASCADE,OnDelete:RESTRICT"`
 }
 
+// Book is a single work in the catalog, mapping to a Hardcover work. A work may
+// be co-authored, so Authors is many-to-many — a book lists every tracked author
+// who contributed it. HardcoverRef is nil for provisional books (acquired from a
+// feed before being resolved to a Hardcover work).
+type Book struct {
+	CommonFields
+	Authors      []Author `gorm:"many2many:book_authors;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	HardcoverRef *string  `gorm:"uniqueIndex"` // Hardcover work id (decimal string); nil = provisional
+	Title        string   `gorm:"not null"`
+	ReleaseDate  *time.Time
+}
+
+// AcquisitionTarget is the unit of "wanted vs. satisfied": one per (Book × media
+// type). Its existence means that media type is wanted; Satisfied flips once a
+// release fills it. The catalog spine is Book → AcquisitionTarget → DownloadRecord.
+type AcquisitionTarget struct {
+	CommonFields
+	BookID     uint     `gorm:"not null;uniqueIndex:idx_acq_book_booktype"`
+	Book       Book     `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	BookTypeID uint     `gorm:"not null;uniqueIndex:idx_acq_book_booktype"`
+	BookType   BookType `gorm:"constraint:OnUpdate:CASCADE,OnDelete:RESTRICT"`
+	Satisfied  bool     `gorm:"not null;default:false"`
+}
+
 // AuthorSubscriptionItem represents a downloaded item from an AuthorSubscription
 type AuthorSubscriptionItem struct {
 	CommonFields


### PR DESCRIPTION
## Summary

- Add `catalog.SyncAuthorBibliography` to materialize each Hardcover-linked author's works as `Book` rows, upserting on `hardcover_ref` so re-runs update rather than duplicate.
- Co-authored works link to every tracked contributor via a `Book`↔`Author` many-to-many instead of squashing to a single `AuthorID`.
- Exposed via `doctor sync-bibliography`.
- Move Hardcover request spacing into the shared client: a token-bucket limiter (50/min, burst 5) on an `http.RoundTripper`, so every call site (sync, web author-add, doctor backfill) shares one budget instead of pacing independently. Drops the manual `time.Sleep` from `backfillHardcoverRefs`.

## Test plan

- `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)